### PR TITLE
Show author events on speaker page

### DIFF
--- a/wp-event-solution/templates/speaker-one.php
+++ b/wp-event-solution/templates/speaker-one.php
@@ -191,6 +191,27 @@
                     </div>
                 </div>
             </div>
+
+            <?php
+                $events = \Etn\Utils\Helper::events_by_author( $author_id );
+                if ( $events ) :
+            ?>
+                <div class="etn-speaker-events">
+                    <h3 class="etn-title">
+                        <?php echo esc_html__( 'Events by', 'eventin' ) . ' ' . esc_html( $author_name ); ?>
+                    </h3>
+                    <ul class="etn-event-list">
+                        <?php foreach ( $events as $event ) : ?>
+                            <li>
+                                <a href="<?php echo esc_url( get_permalink( $event->ID ) ); ?>">
+                                    <?php echo esc_html( get_the_title( $event->ID ) ); ?>
+                                </a>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+
         </div>
     </div>
 

--- a/wp-event-solution/templates/speaker-two-lite.php
+++ b/wp-event-solution/templates/speaker-two-lite.php
@@ -169,7 +169,28 @@ $author_name       = get_the_author_meta( 'display_name', $author_id );
 					</div>
 				</div>
 			</div>
-			<!-- schedule list -->
-		</div>
-	</div>
+                        <!-- schedule list -->
+
+                        <?php
+                            $events = \Etn\Utils\Helper::events_by_author( $author_id );
+                            if ( $events ) :
+                        ?>
+                            <div class="etn-speaker-events">
+                                <h3 class="etn-title">
+                                    <?php echo esc_html__( 'Events by', 'eventin' ) . ' ' . esc_html( $author_name ); ?>
+                                </h3>
+                                <ul class="etn-event-list">
+                                    <?php foreach ( $events as $event ) : ?>
+                                        <li>
+                                            <a href="<?php echo esc_url( get_permalink( $event->ID ) ); ?>">
+                                                <?php echo esc_html( get_the_title( $event->ID ) ); ?>
+                                            </a>
+                                        </li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            </div>
+                        <?php endif; ?>
+
+                </div>
+        </div>
 </div>

--- a/wp-event-solution/utils/helper.php
+++ b/wp-event-solution/utils/helper.php
@@ -1181,7 +1181,7 @@ class Helper {
  * @param int $user_id The ID of the user.
  * @return array The schedule topics related to the user.
  */
-	public static function speaker_sessions($user_id) {
+        public static function speaker_sessions($user_id) {
 		// Initialize an array to hold matched post IDs
 		$matched_posts = [];
 
@@ -1220,8 +1220,31 @@ class Helper {
 
 		// Return the matched post IDs
 		
-		return array_unique($matched_posts);
-	}
+                return array_unique($matched_posts);
+        }
+
+        /**
+         * Get events created by a specific author.
+         *
+         * @param int $user_id The ID of the user.
+         *
+         * @return array List of WP_Post objects
+         */
+        public static function events_by_author( $user_id ) {
+                $args = [
+                        'post_type'      => 'etn',
+                        'post_status'    => 'publish',
+                        'posts_per_page' => -1,
+                        'author'         => $user_id,
+                ];
+
+                $query  = new \WP_Query( $args );
+                $events = $query->posts;
+
+                wp_reset_postdata();
+
+                return $events;
+        }
 	
 	/**
 	 * Remove attendee data when status failed


### PR DESCRIPTION
## Summary
- add `events_by_author` helper for fetching event posts by author
- display author's events in `speaker-one.php` template
- display author's events in `speaker-two-lite.php` template

## Testing
- `php -l wp-event-solution/utils/helper.php`
- `php -l wp-event-solution/templates/speaker-one.php`
- `php -l wp-event-solution/templates/speaker-two-lite.php`


------
https://chatgpt.com/codex/tasks/task_e_68855e682ac883278f93e139971ae61c