### PR TITLE
Allow Elementor overrides for speaker pages

### DIFF
--- a/wp-content/plugins/wp-event-solution/core/speaker/SpeakerTemplate.php
+++ b/wp-content/plugins/wp-event-solution/core/speaker/SpeakerTemplate.php
@@ -31,14 +31,19 @@ class SpeakerTemplate implements HookableInterface {
 		$author_id = get_queried_object_id();
 		$author = get_userdata( $author_id );
 	
-		if ( $author && ( in_array( 'etn-speaker', (array) $author->roles) || in_array('etn-organizer', (array) $author->roles ) ) ) {
-			// Path to your custom author template in the plugin folder
-			$custom_template = \Wpeventin::templates_dir() . 'speaker/single-author.php';
-			// If the file exists, use it
-			if ( file_exists( $custom_template ) ) {
-				return $custom_template;
-			}
-		}
+                if ( $author && ( in_array( 'etn-speaker', (array) $author->roles) || in_array('etn-organizer', (array) $author->roles ) ) ) {
+                        // Allow Elementor Theme Builder to override the author page
+                        if ( function_exists( 'elementor_theme_has_location' ) && ( elementor_theme_has_location( 'author' ) || elementor_theme_has_location( 'archive' ) ) ) {
+                                return $template;
+                        }
+
+                        // Path to your custom author template in the plugin folder
+                        $custom_template = \Wpeventin::templates_dir() . 'speaker/single-author.php';
+                        // If the file exists, use it
+                        if ( file_exists( $custom_template ) ) {
+                                return $custom_template;
+                        }
+                }
 	
 		return $template;
 	}
@@ -49,6 +54,11 @@ class SpeakerTemplate implements HookableInterface {
      * @return  void
      */
     public function include_single_template() {
+        if ( function_exists( 'elementor_theme_has_location' ) && elementor_theme_has_location( 'single' ) ) {
+            elementor_theme_do_location( 'single' );
+            return;
+        }
+
         $default_template_name = "speaker-one";
         $settings              = etn_get_option();
         $template_name         = !empty( $settings['speaker_template'] ) ? $settings['speaker_template'] : $default_template_name;

--- a/wp-content/plugins/wp-event-solution/core/speaker/template-functions.php
+++ b/wp-content/plugins/wp-event-solution/core/speaker/template-functions.php
@@ -152,6 +152,11 @@ if ( !function_exists( 'speaker_objective' ) ) {
 
 if ( !function_exists( 'etn_single_speaker_template_select' ) ) {
     function etn_single_speaker_template_select() {
+        if ( function_exists( 'elementor_theme_has_location' ) && elementor_theme_has_location( 'single' ) ) {
+            elementor_theme_do_location( 'single' );
+            return;
+        }
+
         $default_template_name = "speaker-one";
         $settings              = etn_get_option();
         $template_name         = !empty( $settings['speaker_template'] ) ? $settings['speaker_template'] : $default_template_name;


### PR DESCRIPTION
## Summary
- allow Elementor Theme Builder to override speaker author pages
- support Elementor single templates for speakers

## Testing
- `php -l wp-content/plugins/wp-event-solution/core/speaker/SpeakerTemplate.php`
- `php -l wp-content/plugins/wp-event-solution/core/speaker/template-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_6891656f994c832798e36fd999137d4a