### PR TITLE
Implement speaker page header and event grid

### DIFF
--- a/wp-content/themes/most-child/functions.php
+++ b/wp-content/themes/most-child/functions.php
@@ -12,3 +12,30 @@ function allow_svg_upload($mimes) {
     return $mimes;
 }
 add_filter('upload_mimes', 'allow_svg_upload');
+
+add_filter( 'etn_speaker_content_template_path', 'most_child_custom_speaker_template' );
+
+function most_child_custom_speaker_template( $path ) {
+    $custom = get_stylesheet_directory() . '/templates/speaker-grid.php';
+    if ( file_exists( $custom ) ) {
+        return $custom;
+    }
+    return $path;
+}
+
+add_action( 'after_setup_theme', function() {
+    add_image_size( 'speaker-event', 1024, 512, true );
+} );
+
+add_action( 'init', function() {
+    foreach ( get_post_types() as $post_type ) {
+        if ( post_type_supports( $post_type, 'comments' ) ) {
+            remove_post_type_support( $post_type, 'comments' );
+            remove_post_type_support( $post_type, 'trackbacks' );
+        }
+    }
+} );
+
+add_filter( 'comments_open', '__return_false', 20, 2 );
+add_filter( 'pings_open', '__return_false', 20, 2 );
+add_filter( 'comments_array', '__return_empty_array', 10, 2 );

--- a/wp-content/themes/most-child/style.css
+++ b/wp-content/themes/most-child/style.css
@@ -14,4 +14,73 @@ Template: most
 */
 
 /* Add your own modification from here
------
+--------------------------------------------------------------*/
+
+.speaker-header {
+    color: #fff;
+    padding: 80px 0;
+    background-size: cover;
+    background-position: center;
+}
+
+.speaker-header .speaker-title {
+    font-family: var(--font-heading);
+}
+
+.speaker-header .speaker-bio,
+.speaker-events-grid .event-title,
+.speaker-events-grid .event-date {
+    font-family: var(--font-primary, sans-serif);
+}
+
+.speaker-container {
+    max-width: 1140px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.speaker-logo {
+    text-align: right;
+    margin: 20px 0;
+}
+
+.speaker-logo img {
+    width: 25%;
+    height: auto;
+    border-radius: var(--radius-md);
+}
+
+.speaker-events-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 30px;
+}
+
+.speaker-events-grid .event-item a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.event-thumb {
+    width: 100%;
+    aspect-ratio: 2 / 1;
+    overflow: hidden;
+    border-radius: var(--radius-md);
+}
+
+.event-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.speaker-events-grid .event-title {
+    margin: 10px 0 5px;
+    font-size: 1.2em;
+}
+
+.speaker-events-grid .event-date {
+    font-size: 0.9em;
+    color: #666;
+}

--- a/wp-content/themes/most-child/templates/speaker-grid.php
+++ b/wp-content/themes/most-child/templates/speaker-grid.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Custom speaker template with event grid.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use \Etn\Utils\Helper;
+
+$author_id         = get_queried_object_id();
+$author_name       = get_the_author_meta( 'display_name', $author_id );
+$author_bio        = get_the_author_meta( 'description', $author_id );
+$speaker_thumbnail = get_user_meta( $author_id, 'image', true );
+$logo              = get_user_meta( $author_id, 'etn_speaker_company_logo', true );
+$events            = Helper::events_by_author( $author_id );
+?>
+<div class="speaker-page">
+    <header class="speaker-header" style="<?php echo $speaker_thumbnail ? 'background-image:url(' . esc_url( $speaker_thumbnail ) . ');' : ''; ?>">
+        <div class="speaker-container">
+            <h1 class="speaker-title"><?php echo esc_html( $author_name ); ?></h1>
+            <?php if ( $author_bio ) : ?>
+                <p class="speaker-bio"><?php echo esc_html( $author_bio ); ?></p>
+            <?php endif; ?>
+        </div>
+    </header>
+
+    <div class="speaker-container">
+        <?php if ( $logo ) : ?>
+            <div class="speaker-logo">
+                <img src="<?php echo esc_url( $logo ); ?>" alt="<?php echo esc_attr( $author_name ); ?>">
+            </div>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $events ) ) : ?>
+            <div class="speaker-events-grid">
+                <?php foreach ( $events as $event ) :
+                    $thumb          = get_the_post_thumbnail_url( $event->ID, 'speaker-event' );
+                    $date           = get_post_meta( $event->ID, 'etn_start_date', true );
+                    $formatted_date = $date ? date_i18n( get_option( 'date_format' ), strtotime( $date ) ) : '';
+                    ?>
+                    <div class="event-item">
+                        <a href="<?php echo esc_url( get_permalink( $event->ID ) ); ?>">
+                            <?php if ( $thumb ) : ?>
+                                <div class="event-thumb">
+                                    <img src="<?php echo esc_url( $thumb ); ?>" alt="<?php echo esc_attr( get_the_title( $event->ID ) ); ?>">
+                                </div>
+                            <?php endif; ?>
+                            <h3 class="event-title"><?php echo esc_html( get_the_title( $event->ID ) ); ?></h3>
+                            <?php if ( $formatted_date ) : ?>
+                                <div class="event-date"><?php echo esc_html( $formatted_date ); ?></div>
+                            <?php endif; ?>
+                        </a>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Add speaker page container, theme fonts, and image rounding
- Enforce 1024x512 event images with new size and aspect ratio
- Disable all WordPress comments across post types

## Testing
- `php -l wp-content/themes/most-child/functions.php`
- `php -l wp-content/themes/most-child/templates/speaker-grid.php`


------
https://chatgpt.com/codex/tasks/task_e_689179552df48327a016447e27f2f1a9